### PR TITLE
chore: Remove references to lib/pcs_core path

### DIFF
--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -223,7 +223,7 @@ module Translator
       end
 
       def translation_file
-        @translation_file || Rails.root.join('lib', 'pcs_core', '.in_progress_translations')
+        @translation_file || Rails.root.join('.in_progress_translations')
       end
 
       def format

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -361,5 +361,5 @@ module Translator
 
   end
 
-  Translator.default_dir = Rails.root.join('lib/pcs_core/config/locales/cardholder')
+  Translator.default_dir = Rails.root.join('config/locales/cardholder')
 end

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -361,5 +361,5 @@ module Translator
 
   end
 
-  Translator.default_dir = 'lib/pcs_core/config/locales/cardholder'
+  Translator.default_dir = Rails.root.join('lib/pcs_core/config/locales/cardholder')
 end


### PR DESCRIPTION
Once [this `pcs_core` PR](https://github.com/b4b-payments/pcs_core/pull/2558) is merged, the `DIR` environment variable will always be set when this gem is invoked from `pcs_core`. Consequently, the defaulting of the directory to `lib/pcs_core/config/locales/cardholder` will not be necessary.

We leave the defaulting behaviour in place, but remove the `lib/pcs_core/` prefix; this is based on the optimistic assumption that the locale files in `pcs_core` will soon be moved out of the `lib/pcs_core` subdirectory.

Also place the `.in_progress_translations` tracking file at the top level, instead of in the `lib/pcs_core` subdirectory.

> [!WARNING]
> There is a small risk that this would break any in-progress translation tracking, were a developer to commit the tracking file before `translator` is updated in `pcs_core`. We can mitigate this by only updating the `translator` dependency in `pcs_core` if the tracking file is not present in the `development` branch.