### PR TITLE
fix: Remove Rails.root reference

### DIFF
--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -361,5 +361,5 @@ module Translator
 
   end
 
-  Translator.default_dir = Rails.root.join('config/locales/cardholder')
+  Translator.default_dir = 'config/locales/cardholder'
 end


### PR DESCRIPTION
This causes problems when the gem is loaded into pcs_core.

Fixes a problem introduced in #2.