### PR TITLE
[CARDS-1205] Allow Rails v7.1

### DIFF
--- a/translator.gemspec
+++ b/translator.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 4.0", "< 7.1"
+  s.add_dependency "rails", ">= 4.0", "< 7.2"
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'minitest-rails'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
Relaxing the Rails version will allow us to work on upgrading `pcs_core` from Rails 7.0 to 7.1.

[Jira ticket](https://b4bpayments.atlassian.net/browse/CARDS-1205)