### PR TITLE
[CARDS-1193] Allow Rails 7.2 and 8.0

### DIFF
--- a/translator.gemspec
+++ b/translator.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 4.0", "< 7.2"
+  s.add_dependency "rails", ">= 4.0", "< 8.1"
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'minitest-rails'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
## Synopsis

Unblocks upgrade of Rails to v7.2 and v8.0 in main `pcs_core` app.

[Jira ticket](https://b4bpayments.atlassian.net/browse/CARDS-1193)