### PR TITLE
Allow aliases in YAML

### DIFF
--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -291,7 +291,7 @@ module Translator
     end
 
     def read_translation_file file_path
-      file_path.end_with?('json') ? JSON.load_file(file_path) : YAML.load_file(file_path)
+      file_path.end_with?('json') ? JSON.load_file(file_path) : YAML.load_file(file_path, aliases: true)
     end
 
     def path(locale)

--- a/lib/translator/version.rb
+++ b/lib/translator/version.rb
@@ -1,3 +1,3 @@
 module Translator
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
This is needed for this [PR](https://github.com/b4b-payments/pcs_core/pull/5748) which uses aliases in the yaml. The aliased yaml works fine in the app however the lack of alias support in this repo causes the missing translation test to fail.

I'm also going to add a tag for this release (`0.0.2`) and set the main app to use the tag instead of just the git repo (
`gem "translator", git: "git@github.com:b4b-payments/translator.git"`
to
`gem "translator", git: "git@github.com:b4b-payments/translator.git, tag: "0.0.2"`
)